### PR TITLE
fix: find contents in rootfolder of repo instead of in /docker

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -8,10 +8,11 @@ nvidia-docker run --rm -it \
  --name xbot2examples \
  --publish 8080:8080 \
  --publish 8888:8888 \
- -v $(pwd)/src:/home/user/src/xbot2_examples/src \
- -v $(pwd)/world:/home/user/src/xbot2_examples/world \
- -v $(pwd)/config:/home/user/src/xbot2_examples/config \
- -v $(pwd)/CMakeLists.txt:/home/user/src/xbot2_examples/CMakeLists.txt \
+ -v $(pwd)/../src:/home/user/src/xbot2_examples/src \
+ -v $(pwd)/../world:/home/user/src/xbot2_examples/world \
+ -v $(pwd)/../config:/home/user/src/xbot2_examples/config \
+ -v $(pwd)/../CMakeLists.txt:/home/user/src/xbot2_examples/CMakeLists.txt \
  arturolaurenzi/xbot2:examples \
  bash
+
 


### PR DESCRIPTION
elsewhere two issues arise: 

1. when run.sh for the first time, this error appears:
 ```
$ ./run.sh
docker: Error response from daemon: OCI runtime create failed: container_linux.go:367: starting container process caused: process_linux.go:495: container init caused: rootfs_linux.go:60: mounting "/home/user/project_name/xbot2_examples/docker/CMakeLists.txt" to rootfs at "/var/lib/docker/overlay2/0a5cd48f30f269f04cfbf09599be21fe9efc8c1559debf7ee623c211e01860f5/merged/home/user/src/xbot2_examples/CMakeLists.txt" caused: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type.
```
 2. when running the docker the xbot2 config file can not be found. 
 
 With the proposed fix, everything can be run as expected.