### PR TITLE
add real-time priorities to docker.

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -2,10 +2,15 @@
 
 set -e
 
-nvidia-docker run --rm -it \
+sudo nvidia-docker run --rm -it \
  --env="DISPLAY=$DISPLAY" \
  --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
  --name xbot2examples \
+ --network host \
+ --ulimit rtprio=99 \
+ --cap-add=sys_nice \
+ --cap-add ipc_lock \
+ --device=/dev/cpu_dma_latency \
  --publish 8080:8080 \
  --publish 8888:8888 \
  -v $(pwd)/src:/home/user/src/xbot2_examples/src \


### PR DESCRIPTION
Added parameters to `nvidia-docker run` command to enable real-time capabilities<sup>[1](https://docs.docker.com/engine/reference/run/)</sup> inside container running on real-time host operating system. Tested with both non real time and `PREEMPT_RT` patched system. 

[1] [https://docs.docker.com/engine/reference/run/](https://docs.docker.com/engine/reference/run/)